### PR TITLE
feat: Gemini APIによるタスクのAI細分化機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ supabase/.temp/
 .claude/settings.local.json
 CLAUDE.local.md
 .claude/memory.md
+
+# === 旧タスク管理アプリ（参照用、移植完了後に削除予定） ===
+frontend/src/app/tasks/old-taskmanager/
+
+# === 個人用ファイル（振り返りメモ等、今後もここに追加） ===
+.claude/private/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,7 @@ CORS_ORIGINS=["http://localhost:3000"]
 
 # App
 DEBUG=true
+
+# Gemini API (AI subdivision)
+GEMINI_API_KEY=your-gemini-api-key
+GEMINI_MODEL=gemma-4-31b-it

--- a/backend/app/api/v1/endpoints/tasks.py
+++ b/backend/app/api/v1/endpoints/tasks.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.services.task_service import TaskService
+from app.services.gemini_service import GeminiServiceError
 from app.schemas.task import (
     TaskResponse,
     TaskCreate,
@@ -141,6 +142,25 @@ async def create_subtask(
     if "category" not in data:
         data["category"] = parent.category
     return service.create_task(user_id=user_id, data=data)
+
+
+@router.post("/{task_id}/subdivide", response_model=list[TaskResponse])
+async def subdivide_task(
+    task_id: str,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """AIで親タスクをサブタスクに自動分割"""
+    service = TaskService(db)
+    parent = service.get_task(task_id=task_id, user_id=user_id)
+    if not parent:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if parent.status == "done":
+        raise HTTPException(status_code=400, detail="完了済みタスクは細分化できません")
+    try:
+        return await service.subdivide_task(parent)
+    except GeminiServiceError as e:
+        raise HTTPException(status_code=502, detail=str(e))
 
 
 @router.delete("/{task_id}", status_code=204)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     secret_key: str = "change-me"
     cors_origins: List[str] = ["http://localhost:3000"]
     debug: bool = False
+    gemini_api_key: str = ""
+    gemini_model: str = "gemma-4-31b-it"
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -52,6 +52,7 @@ class Task(Base):
         back_populates="parent",
         cascade="all, delete-orphan",
         lazy="selectin",
+        order_by="Task.created_at",
     )
     parent = relationship(
         "Task",

--- a/backend/app/services/gemini_service.py
+++ b/backend/app/services/gemini_service.py
@@ -1,0 +1,140 @@
+import asyncio
+import json
+import re
+from datetime import datetime
+
+import httpx
+
+from app.core.config import settings
+from app.models.task import Task
+
+GEMINI_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+# 恒常的なルールはsystemInstructionに分離し、per-requestプロンプトはタスク固有データのみに絞る
+SYSTEM_INSTRUCTION = (
+    "あなたはタスク管理アプリのAIアシスタントです。"
+    "与えられた親タスクを、指示された条件に従って具体的なサブタスクに分割してください。\n"
+    "厳守事項:\n"
+    "- 提示された既存サブタスクと重複する内容は生成しない\n"
+    "- 日付は親タスクの期間内に収め、YYYY-MM-DD形式で開始日の早い順に並べる\n"
+    "- titleは10〜20文字程度で簡潔に、descriptionは1〜2文で具体的な作業内容を書く\n"
+    "- 指示された個数の範囲を必ず守る（1個だけの分割や、範囲外の個数は不可）"
+)
+
+# responseSchemaで構造を強制すると、この検証環境ではモデルの思考(thought)ステップが省略され
+# レイテンシが大幅に改善された（実測: 約30秒 → 6〜8秒）ため、JSON整形もモデル任せにしない。
+# 個数は指示分岐（1日/2〜4日/それ以上）のいずれでも常に2〜4件になるよう設計しているため、
+# minItems/maxItemsで下限を強制し、指示文だけでは守られない「1個だけ生成」を防ぐ
+RESPONSE_SCHEMA = {
+    "type": "ARRAY",
+    "minItems": 2,
+    "maxItems": 4,
+    "items": {
+        "type": "OBJECT",
+        "properties": {
+            "title": {"type": "STRING"},
+            "description": {"type": "STRING"},
+            "start_date": {"type": "STRING"},
+            "due_date": {"type": "STRING"},
+        },
+        "required": ["title", "start_date", "due_date"],
+    },
+}
+
+
+class GeminiServiceError(Exception):
+    pass
+
+
+def _build_user_content(task: Task, effective_start: datetime, effective_due: datetime) -> str:
+    existing = (
+        "\n".join(
+            f"- {s.title} ({_fmt(s.start_date)} ~ {_fmt(s.due_date)})"
+            for s in task.sub_tasks
+        )
+        or "なし"
+    )
+
+    days = (effective_due.date() - effective_start.date()).days + 1
+
+    if days <= 1:
+        instr = (
+            f"期間は1日です({_fmt(effective_start)})。"
+            "必ず2〜4個（1個は不可）のサブタスクに分割してください。"
+            f"全ての日付は {_fmt(effective_start)} です。"
+        )
+    elif days <= 4:
+        instr = f"期間は{days}日です。1日につき1つのサブタスクを作成し、必ず合計{days}個にしてください。"
+    else:
+        instr = f"期間は{days}日です。期間を連続させて必ず2〜4個のフェーズに分割してください。"
+
+    return f"""親タスク: "{task.title}"
+内容: "{task.description or ''}"
+期間: {_fmt(effective_start)} ~ {_fmt(effective_due)}
+既存サブタスク（重複禁止）:
+{existing}
+
+指示:
+{instr}"""
+
+
+def _fmt(d: datetime | None) -> str:
+    return d.date().isoformat() if d else ""
+
+
+async def generate_subtask_suggestions(
+    task: Task, effective_start: datetime, effective_due: datetime
+) -> list[dict]:
+    if not settings.gemini_api_key:
+        raise GeminiServiceError("GEMINI_API_KEYが設定されていません")
+
+    prompt = _build_user_content(task, effective_start, effective_due)
+    url = GEMINI_ENDPOINT.format(model=settings.gemini_model)
+    payload = {
+        "systemInstruction": {"parts": [{"text": SYSTEM_INSTRUCTION}]},
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "temperature": 0.4,
+            "responseMimeType": "application/json",
+            "responseSchema": RESPONSE_SCHEMA,
+        },
+    }
+
+    # gemma-4-31b-itは高負荷時に5xx（"Internal error encountered"等）を一定確率で返すため、
+    # API自身が"temporary"と案内する一時エラーに限り1回だけ再試行する
+    res = None
+    for attempt in range(2):
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                res = await client.post(
+                    url,
+                    params={"key": settings.gemini_api_key},
+                    json=payload,
+                )
+            res.raise_for_status()
+            break
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code < 500 or attempt == 1:
+                raise GeminiServiceError(f"Gemini APIへの接続に失敗しました: {e}") from e
+            await asyncio.sleep(1.5)
+        except httpx.HTTPError as e:
+            raise GeminiServiceError(f"Gemini APIへの接続に失敗しました: {e or type(e).__name__}") from e
+
+    body = res.json()
+    try:
+        parts = body["candidates"][0]["content"]["parts"]
+        # 推論系モデル（gemma-4等）はthought=trueの思考過程パートを先に返すため除外する
+        text = next(p["text"] for p in reversed(parts) if not p.get("thought") and "text" in p)
+    except (KeyError, IndexError, StopIteration) as e:
+        raise GeminiServiceError("Gemini APIの応答が不正です") from e
+
+    cleaned = re.sub(r"```json|```", "", text).strip()
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise GeminiServiceError("Gemini APIの応答をJSONとして解析できませんでした") from e
+
+    if not isinstance(parsed, list):
+        raise GeminiServiceError("Gemini APIの応答形式が不正です")
+
+    return parsed

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -1,10 +1,11 @@
 from typing import Optional, List
 from sqlalchemy.orm import Session
 from sqlalchemy import asc, desc
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 from app.models.task import Task
+from app.services.gemini_service import generate_subtask_suggestions
 
 _SORT_COLUMNS = {
     "due_date": Task.due_date,
@@ -129,6 +130,66 @@ class TaskService:
         self.db.delete(task)
         self.db.commit()
         return True
+
+    async def subdivide_task(self, parent: Task) -> List[Task]:
+        """AIで親タスクをサブタスクに自動分割"""
+        has_start = parent.start_date is not None
+        has_due = parent.due_date is not None
+
+        # 期限未設定の場合は今日を期限とみなし、開始日未設定の場合は
+        # 今日（期限が既に過ぎていれば期限日）を開始日として扱う。
+        # これはAIへの個数指示（1日/2〜4日/それ以上）を組み立てるためだけに使い、
+        # 実際に保存するサブタスクの日付は下記の分岐で親の設定状況に応じて決める
+        now = datetime.now(timezone.utc)
+        effective_due = parent.due_date or now
+        effective_start = parent.start_date or min(now, effective_due)
+
+        suggestions = await generate_subtask_suggestions(parent, effective_start, effective_due)
+
+        # 親が日付を1つも設定していなければサブタスクにも日付を付けない。
+        # 片方だけ設定していればサブタスク全件をその1つの日付に揃える。
+        # 両方設定していれば従来どおりAIが提案した個別の期間を（範囲内に収めて）使う
+        if not has_start and not has_due:
+            date_mode = "none"
+        elif has_start != has_due:
+            date_mode = "single"
+            single_date = parent.start_date if has_start else parent.due_date
+        else:
+            date_mode = "range"
+
+        created = []
+        for s in suggestions:
+            if date_mode == "none":
+                start_date = None
+                due_date = None
+            elif date_mode == "single":
+                start_date = single_date
+                due_date = single_date
+            else:
+                start_date = self._parse_date(s.get("start_date"), effective_start)
+                due_date = self._parse_date(s.get("due_date"), effective_due)
+
+            data = {
+                "title": s.get("title") or "新規サブタスク",
+                "description": s.get("description"),
+                "start_date": start_date,
+                "due_date": due_date,
+                "parent_id": parent.id,
+                "tags": parent.tags,
+                "priority": parent.priority,
+                "category": parent.category,
+            }
+            created.append(self.create_task(user_id=parent.user_id, data=data))
+        return created
+
+    @staticmethod
+    def _parse_date(value, fallback):
+        if not value:
+            return fallback
+        try:
+            return datetime.fromisoformat(value)
+        except (TypeError, ValueError):
+            return fallback
 
     def get_tags(self, user_id: str) -> list:
         from sqlalchemy import text

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -4,6 +4,36 @@ import { useState } from "react";
 import { TaskList } from "@/components/tasks/TaskList";
 import { TaskForm } from "@/components/tasks/TaskForm";
 
+// === AI細分化の説明アイコン ===
+function AiFeatureInfo() {
+  return (
+    <div className="group relative flex items-center gap-1 cursor-default">
+      <span className="text-sm text-gray-500 group-hover:text-sfc-blue transition-colors">
+        AI細分化とは
+      </span>
+      <button
+        type="button"
+        aria-label="AI細分化機能について"
+        className="flex text-gray-400 group-hover:text-sfc-blue transition-colors"
+      >
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+        </svg>
+      </button>
+      <div
+        role="tooltip"
+        className="pointer-events-none absolute right-0 top-full mt-2 w-64 rounded-xl border border-gray-200 bg-white p-3 text-xs leading-relaxed text-gray-600 shadow-lg opacity-0 scale-95 origin-top-right transition-all duration-150 group-hover:opacity-100 group-hover:scale-100 z-10"
+      >
+        <p className="mb-1 text-sm font-semibold text-gray-900">AI細分化</p>
+        <p>
+          タイトル・説明・期間をAIが読み取り、ちょうどよい粒度のサブタスクへ自動で分割します。
+          各タスクのカードにある「AI細分化」ボタンから利用でき、期間が未設定の場合は今日を基準に分割します。
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export default function TasksPage() {
   const [showForm, setShowForm] = useState(false);
 
@@ -11,15 +41,18 @@ export default function TasksPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">タスク管理</h1>
-        <button
-          onClick={() => setShowForm(true)}
-          className="btn-primary"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
-          タスクを追加
-        </button>
+        <div className="flex items-center gap-3">
+          <AiFeatureInfo />
+          <button
+            onClick={() => setShowForm(true)}
+            className="btn-primary"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            タスクを追加
+          </button>
+        </div>
       </div>
 
       <TaskList />

--- a/frontend/src/components/tasks/TaskItem.tsx
+++ b/frontend/src/components/tasks/TaskItem.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Fragment, useState, useRef, useEffect, KeyboardEvent } from "react";
-import { useUpdateTask, useDeleteTask, useCreateSubtask } from "@/lib/hooks/useTasks";
+import axios from "axios";
+import { useUpdateTask, useDeleteTask, useCreateSubtask, useSubdivideTask } from "@/lib/hooks/useTasks";
 import { TaskForm } from "./TaskForm";
 import { DateRangePicker } from "./DateRangePicker";
 import type { Task, TaskPriority, TaskStatus } from "@/types/task";
@@ -68,7 +69,7 @@ function SubTaskAddForm({ parentId, onDone }: { parentId: string; onDone: () => 
 
   return (
     <div className="card p-4 space-y-3">
-      <p className="text-xs font-medium text-gray-500">サブタスクを追加</p>
+      <p className="text-sm font-medium text-gray-600">サブタスクを追加</p>
       <input
         ref={titleRef}
         value={title}
@@ -97,7 +98,7 @@ function SubTaskAddForm({ parentId, onDone }: { parentId: string; onDone: () => 
           onChange={(s, e) => { setStartDate(s); setDueDate(e); }}
         />
       </div>
-      <p className="text-xs text-gray-400">優先度・タグ・カテゴリは親タスクから自動引き継ぎ</p>
+      <p className="text-sm text-gray-500">優先度・タグ・カテゴリは親タスクから自動引き継ぎ</p>
       <div className="flex gap-2 justify-end pt-1">
         <button type="button" onClick={onDone}
           className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5">キャンセル</button>
@@ -128,14 +129,14 @@ function ActiveButton({ task }: { task: Task }) {
       onClick={toggle}
       disabled={updateTask.isPending}
       title={isActive ? "進行中（クリックで停止）" : "開始する"}
-      className={`flex-shrink-0 flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border transition-all ${
+      className={`flex-shrink-0 flex items-center gap-1 text-sm font-medium px-2.5 py-1 rounded-full border transition-all ${
         isActive
           ? "bg-sfc-blue text-white border-sfc-blue"
-          : "text-gray-400 border-gray-200 hover:border-sfc-blue hover:text-sfc-blue"
+          : "text-gray-500 border-gray-200 hover:border-sfc-blue hover:text-sfc-blue"
       }`}
     >
       <svg
-        className="w-2.5 h-2.5"
+        className="w-3 h-3"
         fill={isActive ? "currentColor" : "none"}
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -159,6 +160,7 @@ interface TaskCardProps {
 function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
   const updateTask = useUpdateTask();
   const deleteTask = useDeleteTask();
+  const subdivideTask = useSubdivideTask();
   const [descExpanded, setDescExpanded] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
   const [subtasksOpen, setSubtasksOpen] = useState(false);
@@ -193,6 +195,19 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
     setShowAddSubtask(true);
   }
 
+  function handleSubdivideClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    setSubtasksOpen(true);
+    subdivideTask.mutate(task.id, {
+      onError: (err) => {
+        const detail = axios.isAxiosError(err)
+          ? (err.response?.data as { detail?: string } | undefined)?.detail
+          : undefined;
+        window.alert(detail || "AI細分化に失敗しました");
+      },
+    });
+  }
+
   const childBreadcrumb = [...breadcrumb, task.title];
   const isMinimal = depth > 0 && !cardExpanded;
 
@@ -205,10 +220,10 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
         {/* === パンくず (サブタスクのみ) === */}
         {depth > 0 && (
           <div className="px-4 pt-2.5 flex items-center justify-between min-w-0">
-            <div className="flex items-center gap-1 text-xs text-gray-400 min-w-0 overflow-hidden">
+            <div className="flex items-center gap-1 text-xs text-gray-500 min-w-0 overflow-hidden">
               {breadcrumb.map((t, i) => (
                 <Fragment key={i}>
-                  {i > 0 && <span className="flex-shrink-0 text-gray-300">›</span>}
+                  {i > 0 && <span className="flex-shrink-0 text-gray-400">›</span>}
                   <span className="truncate max-w-[7rem]">{t}</span>
                 </Fragment>
               ))}
@@ -217,7 +232,7 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
             {cardExpanded && (
               <button
                 onClick={(e) => { e.stopPropagation(); setCardExpanded(false); }}
-                className="flex-shrink-0 text-gray-300 hover:text-gray-500 transition-colors ml-2"
+                className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors ml-2"
                 title="折りたたむ"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -251,7 +266,7 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
                 {task.title}
               </p>
               {period && (
-                <span className={`text-xs ${overdue ? "text-red-500 font-medium" : "text-gray-400"}`}>
+                <span className={`text-sm ${overdue ? "text-red-500 font-medium" : "text-gray-500"}`}>
                   {overdue ? "期限切れ " : ""}{period}
                 </span>
               )}
@@ -286,15 +301,15 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
               </p>
               <div className="flex items-center gap-2 mt-1 flex-wrap">
                 {period && (
-                  <span className={`text-xs ${overdue ? "text-red-600 font-medium" : "text-gray-500"}`}>
+                  <span className={`text-sm ${overdue ? "text-red-600 font-medium" : "text-gray-600"}`}>
                     {overdue ? "期限切れ " : ""}{period}
                   </span>
                 )}
                 {task.courseName && (
-                  <span className="text-xs text-gray-400">{task.courseName}</span>
+                  <span className="text-sm text-gray-500">{task.courseName}</span>
                 )}
                 {task.tags?.map((tag) => (
-                  <span key={tag} className="text-xs bg-sfc-blue/10 text-sfc-blue px-1.5 py-0.5 rounded-full font-medium">
+                  <span key={tag} className="text-sm bg-sfc-blue/10 text-sfc-blue px-1.5 py-0.5 rounded-full font-medium">
                     #{tag}
                   </span>
                 ))}
@@ -310,7 +325,7 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
                   {showExpandToggle && (
                     <button
                       onClick={(e) => { e.stopPropagation(); setDescExpanded((v) => !v); }}
-                      className="mt-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                      className="mt-1 text-sm text-gray-500 hover:text-gray-700 transition-colors"
                     >
                       {descExpanded ? "折りたたむ ↑" : "すべて表示 ↓"}
                     </button>
@@ -322,12 +337,12 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
             {/* 右側: 状態ボタン・優先度・編集・削除 */}
             <div className="flex items-center gap-1.5 flex-shrink-0">
               <ActiveButton task={task} />
-              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PRIORITY_STYLES[task.priority]}`}>
+              <span className={`text-sm px-2 py-0.5 rounded-full font-medium ${PRIORITY_STYLES[task.priority]}`}>
                 {PRIORITY_LABELS[task.priority]}
               </span>
               <button
                 onClick={(e) => { e.stopPropagation(); setShowEdit(true); }}
-                className="text-gray-300 hover:text-sfc-blue transition-colors"
+                className="text-gray-400 hover:text-sfc-blue transition-colors"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -336,7 +351,7 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
               <button
                 onClick={handleDelete}
                 disabled={deleteTask.isPending}
-                className="text-gray-300 hover:text-red-400 transition-colors"
+                className="text-gray-400 hover:text-red-400 transition-colors"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -355,7 +370,7 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
             {subTaskCount > 0 ? (
               <button
                 onClick={() => setSubtasksOpen((v) => !v)}
-                className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 transition-colors"
+                className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-800 transition-colors"
               >
                 <svg
                   className={`w-3 h-3 transition-transform ${subtasksOpen ? "rotate-90" : ""}`}
@@ -374,18 +389,31 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
                 </span>
               </button>
             ) : (
-              <span className="text-xs text-gray-400">サブタスクなし</span>
+              <span className="text-sm text-gray-500">サブタスクなし</span>
             )}
             {!isDone && (
-              <button
-                onClick={handleAddSubtaskClick}
-                className="text-xs text-gray-400 hover:text-sfc-blue transition-colors flex items-center gap-1"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                </svg>
-                追加
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={handleSubdivideClick}
+                  disabled={subdivideTask.isPending}
+                  title="AIでサブタスクに分割"
+                  className="text-sm font-medium text-gray-600 hover:text-sfc-blue transition-colors flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-600"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
+                  </svg>
+                  {subdivideTask.isPending ? "生成中…" : "AI細分化"}
+                </button>
+                <button
+                  onClick={handleAddSubtaskClick}
+                  className="text-sm font-medium text-gray-600 hover:text-sfc-blue transition-colors flex items-center gap-1.5"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                  </svg>
+                  追加
+                </button>
+              </div>
             )}
           </div>
 

--- a/frontend/src/lib/api/tasks.ts
+++ b/frontend/src/lib/api/tasks.ts
@@ -56,3 +56,9 @@ export async function getAvailableTags(): Promise<string[]> {
   const { data } = await apiClient.get("/tasks/tags");
   return data;
 }
+
+export async function subdivideTask(id: string): Promise<Task[]> {
+  // AI生成はバックエンド側で最大25秒待つため、余裕を持ったタイムアウトを設定
+  const { data } = await apiClient.post(`/tasks/${id}/subdivide`, undefined, { timeout: 35000 });
+  return data;
+}

--- a/frontend/src/lib/hooks/useTasks.ts
+++ b/frontend/src/lib/hooks/useTasks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getTasks, getTask, createTask, updateTask, deleteTask, createSubtask, getAvailableTags } from "@/lib/api/tasks";
+import { getTasks, getTask, createTask, updateTask, deleteTask, createSubtask, getAvailableTags, subdivideTask } from "@/lib/api/tasks";
 import type { Task, TaskCreateInput, TaskUpdateInput, TaskFilters } from "@/types/task";
 
 export function useTasks(filters?: TaskFilters, page = 1, limit = 20) {
@@ -68,6 +68,17 @@ export function useCreateSubtask() {
   return useMutation({
     mutationFn: ({ parentId, input }: { parentId: string; input: TaskCreateInput }) =>
       createSubtask(parentId, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+  });
+}
+
+export function useSubdivideTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => subdivideTask(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },


### PR DESCRIPTION
## Summary

タスク機能フェーズ2として、親タスクをGemini APIで自動的に複数のサブタスクへ分割する「AI細分化」機能を実装。

### UI/UX
- 視認性向上: カード上の薄いグレー文字（ボタン・タグ・優先度・期限表示等）を濃く／大きく統一
- 「AI細分化とは」の説明ツールチップをページ右上に新設
- 日付未設定タスクでもAI細分化が利用できるよう対応（完了済みタスクのみ利用不可）

### バックエンド（Gemini API関連）
- `POST /tasks/{id}/subdivide` を新設。APIキーはバックエンドのみで保持し、フロントに露出させない
- モデルは `gemma-4-31b-it`（RPD重視）
- `systemInstruction`/`responseSchema` によるプロンプト最適化でレイテンシを約3〜5倍改善
- 個数指示（2〜4個）をスキーマの`minItems`/`maxItems`で強制
- モデル側の高いエラー率に対し、5xxエラー限定の1回リトライを実装
- 開始日・期限が一方または両方未設定でも動作するフォールバック
  - 未設定時: サブタスクも日付なし
  - 片方のみ設定時: 全サブタスクをその日付に揃える
  - 両方設定時: 従来どおり期間内で個別の日付範囲に分割
- サブタスクの並び順を`created_at`昇順で保証

## Test plan

- [x] `curl`によるバックエンド単体E2E確認（400/502/200、日数パターン別の生成個数）
- [x] Playwrightでフロントエンドを実機操作し、ボタンの有効/無効・クリック→生成→UI反映を確認
- [x] 日付なし／期限のみ／開始日のみ／両方ありの4パターンでサブタスクの日付・並び順を確認
- [x] `tsc --noEmit` / `py_compile` でのビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)