### PR TITLE
feat: Google OAuth認証基盤とAI細分化のコスト保護

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 # Supabase
+# SUPABASE_URLはJWT検証用のJWKSエンドポイント（<url>/auth/v1/.well-known/jwks.json）取得にも使う
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_KEY=your-service-role-key
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.security import InvalidTokenError, decode_supabase_jwt
+from app.db.session import get_db
+from app.models.user import User
+
+# ローカル開発（DEBUG=true）でAuthorizationヘッダが無い場合のみ使うフォールバックユーザー
+DEV_USER_ID = "00000000-0000-0000-0000-000000000001"
+_DEV_PAYLOAD = {
+    "sub": DEV_USER_ID,
+    "email": "dev@sfc-portal.local",
+    "user_metadata": {"full_name": "Dev User"},
+}
+
+
+def _extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return None
+    return authorization.split(" ", 1)[1]
+
+
+def get_current_user_payload(authorization: Optional[str] = Header(None)) -> dict:
+    """JWTを検証し、生のペイロードを返す。DB上にusers行があるかは問わない（=未登録でも通る）"""
+    token = _extract_bearer_token(authorization)
+
+    if token is None:
+        if settings.debug:
+            return _DEV_PAYLOAD
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Authorization header missing")
+
+    try:
+        return decode_supabase_jwt(token)
+    except InvalidTokenError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid or expired token")
+
+
+def get_current_user_id(payload: dict = Depends(get_current_user_payload)) -> str:
+    return payload["sub"]
+
+
+def require_registered_user_id(
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> str:
+    """usersテーブルに登録済みであることを要求する。未登録ならアカウント作成確認画面へ誘導させるため403を返す"""
+    if not db.get(User, user_id):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "account_not_registered")
+    return user_id

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -54,10 +54,13 @@ async def delete_account(
 @router.get("/users/{user_id}/profile", response_model=UserProfileResponse)
 async def get_user_profile(
     user_id: str,
-    _: str = Depends(get_current_user_id),
+    current_user_id: str = Depends(get_current_user_id),
     db: Session = Depends(get_db),
 ):
-    """Get user profile by ID"""
+    """Get user profile by ID（現状は自分自身のみ。他ユーザーのプロフィール閲覧はSNS機能実装時に
+    公開範囲を設計した上で許可する）"""
+    if user_id != current_user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     user = db.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -1,22 +1,83 @@
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user_id, get_current_user_payload, require_registered_user_id
+from app.db.session import get_db
+from app.models.task import Task
+from app.models.user import User
+from app.services.user_service import get_or_create_user
 from app.schemas.user import UserResponse, UserProfileResponse, UserProfileUpdate
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.get("/me", response_model=UserResponse)
-async def get_current_user():
-    """Get current authenticated user"""
-    raise NotImplementedError
+async def get_current_user(
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get current authenticated user（未登録なら404。フロントはこれを「要アカウント作成確認」の合図として使う）"""
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.post("/register", response_model=UserResponse, status_code=201)
+async def register(
+    payload: dict = Depends(get_current_user_payload),
+    db: Session = Depends(get_db),
+):
+    """Googleログイン後、ユーザーが確認画面で明示的に同意した後にのみusers行を作成する"""
+    return get_or_create_user(db, payload)
+
+
+@router.delete("/me", status_code=204)
+async def delete_account(
+    user_id: str = Depends(require_registered_user_id),
+    db: Session = Depends(get_db),
+):
+    """アカウントを削除する。保有する全タスク（サブタスク含む）も削除される"""
+    top_level_tasks = (
+        db.query(Task).filter(Task.user_id == user_id, Task.parent_id.is_(None)).all()
+    )
+    for task in top_level_tasks:
+        db.delete(task)  # sub_tasksはcascade="all, delete-orphan"で連鎖削除される
+
+    user = db.get(User, user_id)
+    if user:
+        db.delete(user)
+
+    db.commit()
 
 
 @router.get("/users/{user_id}/profile", response_model=UserProfileResponse)
-async def get_user_profile(user_id: str):
+async def get_user_profile(
+    user_id: str,
+    _: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
     """Get user profile by ID"""
-    raise NotImplementedError
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
 
 
 @router.patch("/users/me/profile", response_model=UserProfileResponse)
-async def update_profile(updates: UserProfileUpdate):
+async def update_profile(
+    updates: UserProfileUpdate,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
     """Update current user's profile"""
-    raise NotImplementedError
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    for field, value in updates.model_dump(exclude_unset=True).items():
+        setattr(user, field, value)
+
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/app/api/v1/endpoints/tasks.py
+++ b/backend/app/api/v1/endpoints/tasks.py
@@ -1,7 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, Header
+from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional
 from sqlalchemy.orm import Session
 
+from app.api.deps import require_registered_user_id
+from app.core.config import settings
+from app.core.rate_limit import subdivide_limiter
 from app.db.session import get_db
 from app.services.task_service import TaskService
 from app.services.gemini_service import GeminiServiceError
@@ -17,13 +20,6 @@ from app.schemas.task import (
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
-# TODO: replace with real auth dependency once Supabase Auth is wired up
-DEV_USER_ID = "00000000-0000-0000-0000-000000000001"
-
-
-def get_user_id(x_user_id: Optional[str] = Header(None)) -> str:
-    return x_user_id or DEV_USER_ID
-
 
 @router.get("", response_model=TaskListResponse)
 async def get_tasks(
@@ -37,7 +33,7 @@ async def get_tasks(
     sort_order: Optional[str] = Query("asc", pattern="^(asc|desc)$"),
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Get list of tasks with optional filters"""
@@ -60,7 +56,7 @@ async def get_tasks(
 @router.post("", response_model=TaskResponse)
 async def create_task(
     task: TaskCreate,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Create a new task"""
@@ -70,7 +66,7 @@ async def create_task(
 
 @router.get("/tags", response_model=list[str])
 async def get_tags(
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Get all unique tags used by the user"""
@@ -81,7 +77,7 @@ async def get_tags(
 @router.get("/course/{course_id}", response_model=list[TaskResponse])
 async def get_tasks_by_course(
     course_id: str,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Get all tasks for a specific course"""
@@ -92,7 +88,7 @@ async def get_tasks_by_course(
 @router.get("/{task_id}", response_model=TaskResponse)
 async def get_task(
     task_id: str,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Get a specific task by ID"""
@@ -107,7 +103,7 @@ async def get_task(
 async def update_task(
     task_id: str,
     updates: TaskUpdate,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Update an existing task"""
@@ -124,7 +120,7 @@ async def update_task(
 async def create_subtask(
     task_id: str,
     task: TaskCreate,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Create a subtask under a parent task"""
@@ -147,10 +143,12 @@ async def create_subtask(
 @router.post("/{task_id}/subdivide", response_model=list[TaskResponse])
 async def subdivide_task(
     task_id: str,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """AIで親タスクをサブタスクに自動分割"""
+    if not settings.debug:
+        subdivide_limiter.check(user_id)
     service = TaskService(db)
     parent = service.get_task(task_id=task_id, user_id=user_id)
     if not parent:
@@ -160,13 +158,19 @@ async def subdivide_task(
     try:
         return await service.subdivide_task(parent)
     except GeminiServiceError as e:
+        if e.retry_after is not None:
+            raise HTTPException(
+                status_code=429,
+                detail=str(e),
+                headers={"Retry-After": str(e.retry_after), "X-RateLimit-Scope": "api"},
+            )
         raise HTTPException(status_code=502, detail=str(e))
 
 
 @router.delete("/{task_id}", status_code=204)
 async def delete_task(
     task_id: str,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(require_registered_user_id),
     db: Session = Depends(get_db),
 ):
     """Delete a task (and all subtasks)"""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,6 +5,7 @@ from typing import List
 class Settings(BaseSettings):
     supabase_url: str = ""
     supabase_key: str = ""
+    supabase_jwt_audience: str = "authenticated"
     database_url: str = ""
     secret_key: str = "change-me"
     cors_origins: List[str] = ["http://localhost:3000"]

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,44 @@
+import time
+from collections import defaultdict
+
+from fastapi import HTTPException, status
+
+
+class RateLimiter:
+    """プロセス内メモリのみで完結するシンプルなスライディングウィンドウ制限。
+    単一プロセスの小規模運用を前提としており、複数ワーカー/インスタンスに
+    スケールする場合はRedis等の共有ストアに置き換える必要がある。
+    """
+
+    def __init__(self, max_calls: int, period_seconds: float, scope: str | None = None):
+        self.max_calls = max_calls
+        self.period_seconds = period_seconds
+        self.scope = scope
+        self._hits: dict[str, list[float]] = defaultdict(list)
+
+    def check(self, key: str) -> None:
+        now = time.monotonic()
+        window_start = now - self.period_seconds
+        hits = self._hits[key]
+        while hits and hits[0] < window_start:
+            hits.pop(0)
+
+        if len(hits) >= self.max_calls:
+            retry_after = max(1, int(hits[0] + self.period_seconds - now) + 1)
+            headers = {"Retry-After": str(retry_after)}
+            if self.scope:
+                headers["X-RateLimit-Scope"] = self.scope
+            raise HTTPException(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                "リクエストが多すぎます。しばらく待ってから再度お試しください。",
+                headers=headers,
+            )
+        hits.append(now)
+
+
+# Gemini APIを呼ぶ細分化エンドポイント専用。無料枠のコスト/レート上限を守るため1ユーザーあたり厳しめに絞る。
+# scope="user"はフロントが「あなた自身が制限中」と「Gemini API全体が制限中」を区別するためのタグ
+subdivide_limiter = RateLimiter(max_calls=10, period_seconds=3600, scope="user")
+
+# API全体に対する簡易フラッド対策（IP単位）。通常のブラウジングでは到達しない緩めの閾値にしてある
+global_limiter = RateLimiter(max_calls=300, period_seconds=60, scope="ip")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,37 @@
+import jwt
+from jwt import PyJWKClient
+
+from app.core.config import settings
+
+
+class InvalidTokenError(Exception):
+    pass
+
+
+_jwks_client: PyJWKClient | None = None
+
+
+def _get_jwks_client() -> PyJWKClient:
+    """SupabaseのJWKSエンドポイントから署名検証用の公開鍵を取得・キャッシュするクライアント。
+    このプロジェクトは新方式のJWT Signing Keys（非対称鍵、ES256）を使っているため、
+    共有シークレットによるHS256検証ではなく公開鍵によるJWKS検証を行う。
+    """
+    global _jwks_client
+    if _jwks_client is None:
+        jwks_url = f"{settings.supabase_url}/auth/v1/.well-known/jwks.json"
+        _jwks_client = PyJWKClient(jwks_url, cache_keys=True)
+    return _jwks_client
+
+
+def decode_supabase_jwt(token: str) -> dict:
+    """Supabase Authが発行したaccess_tokenを検証する（JWKS経由の非対称鍵検証）"""
+    try:
+        signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["ES256", "RS256"],
+            audience=settings.supabase_jwt_audience,
+        )
+    except jwt.PyJWTError as e:
+        raise InvalidTokenError(str(e)) from e

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -7,11 +9,22 @@ from app.core.config import settings
 from app.core.rate_limit import global_limiter
 from app.api.v1.router import api_router
 
+logger = logging.getLogger(__name__)
+
 _RATE_LIMIT_EXEMPT_PATHS = {"/health", "/docs", "/openapi.json", "/redoc"}
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # rate_limit.pyのRateLimiterはプロセス内メモリのみで完結する。
+    # 複数ワーカー/複数インスタンスで動かすと各プロセスが別々にカウントし、
+    # Gemini APIの無料枠保護が実質的に無効化される（ワーカー数倍まで緩んでしまう）ため、
+    # スケールさせる前に必ずRedis等の共有ストアへ置き換えること
+    if not settings.debug:
+        logger.warning(
+            "rate_limit.RateLimiterはプロセス内メモリのみで動作します。"
+            "複数ワーカー/複数インスタンスで実行する場合はRedis等の共有ストアに置き換えてください。"
+        )
     if settings.debug:
         _ensure_dev_user()
     yield

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,19 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from contextlib import asynccontextmanager
 
 from app.core.config import settings
+from app.core.rate_limit import global_limiter
 from app.api.v1.router import api_router
+
+_RATE_LIMIT_EXEMPT_PATHS = {"/health", "/docs", "/openapi.json", "/redoc"}
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    _ensure_dev_user()
+    if settings.debug:
+        _ensure_dev_user()
     yield
 
 
@@ -39,7 +44,24 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    # ブラウザの既定露出ヘッダーに含まれないため明示する（AI細分化の再試行時間・制限種別の表示に必要）
+    expose_headers=["Retry-After", "X-RateLimit-Scope"],
 )
+
+
+@app.middleware("http")
+async def rate_limit_middleware(request: Request, call_next):
+    # ローカル開発（DEBUG=true）では自分自身の開発作業を妨げないよう素通しする
+    if not settings.debug and request.url.path not in _RATE_LIMIT_EXEMPT_PATHS:
+        client_host = request.client.host if request.client else "unknown"
+        try:
+            global_limiter.check(client_host)
+        except HTTPException as e:
+            return JSONResponse(
+                status_code=e.status_code, content={"detail": e.detail}, headers=e.headers
+            )
+    return await call_next(request)
+
 
 app.include_router(api_router, prefix="/api/v1")
 

--- a/backend/app/services/gemini_service.py
+++ b/backend/app/services/gemini_service.py
@@ -8,6 +8,9 @@ import httpx
 from app.core.config import settings
 from app.models.task import Task
 
+# Gemini自身が429応答のerror.detailsに含めるRetryInfo（例: "retryDelay": "30s"）を拾うためのパターン
+_RETRY_DELAY_PATTERN = re.compile(r"([\d.]+)\s*s")
+
 GEMINI_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
 
 # 恒常的なルールはsystemInstructionに分離し、per-requestプロンプトはタスク固有データのみに絞る
@@ -43,7 +46,51 @@ RESPONSE_SCHEMA = {
 
 
 class GeminiServiceError(Exception):
-    pass
+    def __init__(self, message: str, retry_after: int | None = None):
+        """retry_afterはGemini API自体がレート制限中の場合のみ設定する（何秒後に再試行可能か）"""
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+def _parse_gemini_retry_after(response: httpx.Response) -> int | None:
+    header_value = response.headers.get("retry-after")
+    if header_value and header_value.isdigit():
+        return int(header_value)
+
+    try:
+        body = response.json()
+        for detail in body.get("error", {}).get("details", []):
+            delay = detail.get("retryDelay")
+            if not delay:
+                continue
+            match = _RETRY_DELAY_PATTERN.match(delay)
+            if match:
+                return max(1, round(float(match.group(1))))
+    except (ValueError, json.JSONDecodeError):
+        pass
+    return None
+
+
+# responseSchemaでJSON出力を強制しても、まれにスキーマ強制用の内部指示文が
+# title/descriptionの中に漏れ込むことがある（配列の最後の要素で発生しやすい）。
+# 通常の日本語の作業内容には出てこない語の組み合わせで検出する。
+_LEAK_MARKERS = (
+    "do not include",
+    "extra text",
+    "parseable",
+    "outside the json",
+    "outside of the json",
+)
+
+
+def _is_contaminated(items: list) -> bool:
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        text = f"{item.get('title', '')} {item.get('description', '')}".lower()
+        if any(marker in text for marker in _LEAK_MARKERS):
+            return True
+    return False
 
 
 def _build_user_content(task: Task, effective_start: datetime, effective_due: datetime) -> str:
@@ -100,10 +147,12 @@ async def generate_subtask_suggestions(
         },
     }
 
-    # gemma-4-31b-itは高負荷時に5xx（"Internal error encountered"等）を一定確率で返すため、
-    # API自身が"temporary"と案内する一時エラーに限り1回だけ再試行する
-    res = None
+    # gemma-4-31b-itは高負荷時に5xx（"Internal error encountered"等）やタイムアウトを
+    # 一定確率で返すため、一時的とみなせるエラーに限り1回だけ再試行する。
+    # また、スキーマ強制用の内部指示文がまれに出力内容に漏れ込むことがあるため、
+    # そちらも検出できた場合は同じ枠内で1回だけ再試行する。
     for attempt in range(2):
+        is_last_attempt = attempt == 1
         try:
             async with httpx.AsyncClient(timeout=15.0) as client:
                 res = await client.post(
@@ -112,29 +161,47 @@ async def generate_subtask_suggestions(
                     json=payload,
                 )
             res.raise_for_status()
-            break
         except httpx.HTTPStatusError as e:
-            if e.response.status_code < 500 or attempt == 1:
+            if e.response.status_code == 429:
+                retry_after = _parse_gemini_retry_after(e.response) or 60
+                raise GeminiServiceError(
+                    "Gemini APIの利用上限に達しました（アプリ全体の制限）", retry_after=retry_after
+                ) from e
+            if e.response.status_code < 500 or is_last_attempt:
                 raise GeminiServiceError(f"Gemini APIへの接続に失敗しました: {e}") from e
             await asyncio.sleep(1.5)
+            continue
+        except httpx.TimeoutException as e:
+            if is_last_attempt:
+                raise GeminiServiceError(
+                    f"Gemini APIへの接続がタイムアウトしました: {str(e) or type(e).__name__}"
+                ) from e
+            continue
         except httpx.HTTPError as e:
-            raise GeminiServiceError(f"Gemini APIへの接続に失敗しました: {e or type(e).__name__}") from e
+            raise GeminiServiceError(
+                f"Gemini APIへの接続に失敗しました: {str(e) or type(e).__name__}"
+            ) from e
 
-    body = res.json()
-    try:
-        parts = body["candidates"][0]["content"]["parts"]
-        # 推論系モデル（gemma-4等）はthought=trueの思考過程パートを先に返すため除外する
-        text = next(p["text"] for p in reversed(parts) if not p.get("thought") and "text" in p)
-    except (KeyError, IndexError, StopIteration) as e:
-        raise GeminiServiceError("Gemini APIの応答が不正です") from e
+        body = res.json()
+        try:
+            parts = body["candidates"][0]["content"]["parts"]
+            # 推論系モデル（gemma-4等）はthought=trueの思考過程パートを先に返すため除外する
+            text = next(p["text"] for p in reversed(parts) if not p.get("thought") and "text" in p)
+        except (KeyError, IndexError, StopIteration) as e:
+            raise GeminiServiceError("Gemini APIの応答が不正です") from e
 
-    cleaned = re.sub(r"```json|```", "", text).strip()
-    try:
-        parsed = json.loads(cleaned)
-    except json.JSONDecodeError as e:
-        raise GeminiServiceError("Gemini APIの応答をJSONとして解析できませんでした") from e
+        cleaned = re.sub(r"```json|```", "", text).strip()
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError as e:
+            raise GeminiServiceError("Gemini APIの応答をJSONとして解析できませんでした") from e
 
-    if not isinstance(parsed, list):
-        raise GeminiServiceError("Gemini APIの応答形式が不正です")
+        if not isinstance(parsed, list):
+            raise GeminiServiceError("Gemini APIの応答形式が不正です")
 
-    return parsed
+        if _is_contaminated(parsed):
+            if is_last_attempt:
+                raise GeminiServiceError("Gemini APIの応答に不要な文章が混入しました")
+            continue
+
+        return parsed

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -75,12 +75,16 @@ class TaskService:
             .first()
         )
 
-    def create_task(self, user_id: str, data: dict) -> Task:
-        task = Task(
+    @staticmethod
+    def _build_task(user_id: str, data: dict) -> Task:
+        return Task(
             id=str(uuid.uuid4()),
             user_id=user_id,
             **{k: v for k, v in data.items() if v is not None},
         )
+
+    def create_task(self, user_id: str, data: dict) -> Task:
+        task = self._build_task(user_id, data)
         self.db.add(task)
         self.db.commit()
         self.db.refresh(task)
@@ -157,7 +161,7 @@ class TaskService:
         else:
             date_mode = "range"
 
-        created = []
+        tasks = []
         for s in suggestions:
             if date_mode == "none":
                 start_date = None
@@ -179,8 +183,14 @@ class TaskService:
                 "priority": parent.priority,
                 "category": parent.category,
             }
-            created.append(self.create_task(user_id=parent.user_id, data=data))
-        return created
+            tasks.append(self._build_task(user_id=parent.user_id, data=data))
+
+        # 1件ずつcommitせず、まとめて1トランザクションで確定する（全件成功か全件失敗かのどちらかにする）
+        self.db.add_all(tasks)
+        self.db.commit()
+        for task in tasks:
+            self.db.refresh(task)
+        return tasks
 
     @staticmethod
     def _parse_date(value, fallback):

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -187,9 +187,12 @@ class TaskService:
         if not value:
             return fallback
         try:
-            return datetime.fromisoformat(value)
+            parsed = datetime.fromisoformat(value)
         except (TypeError, ValueError):
             return fallback
+        # Geminiは日付のみ（YYYY-MM-DD）を返すためnaive datetimeになる。
+        # due_date/start_dateはtimezone-aware列なのでUTCとして明示する
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
     def get_tags(self, user_id: str) -> list:
         from sqlalchemy import text

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,38 @@
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+
+
+def get_or_create_user(db: Session, jwt_payload: dict) -> User:
+    """初回ログイン時にusers行を作成し、以降はGoogleプロフィールの変更を追従させる。
+    bio/interests/graduation_year/grade/facultyはユーザーが手動編集する項目なので上書きしない。
+    """
+    user_id = jwt_payload["sub"]
+    metadata = jwt_payload.get("user_metadata") or {}
+    email = jwt_payload.get("email", "")
+    display_name = metadata.get("full_name") or metadata.get("name") or email
+    avatar_url = metadata.get("avatar_url") or metadata.get("picture")
+
+    user = db.get(User, user_id)
+    if user is None:
+        user = User(id=user_id, email=email, display_name=display_name, avatar_url=avatar_url)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+
+    changed = False
+    if email and user.email != email:
+        user.email = email
+        changed = True
+    if display_name and user.display_name != display_name:
+        user.display_name = display_name
+        changed = True
+    if avatar_url and user.avatar_url != avatar_url:
+        user.avatar_url = avatar_url
+        changed = True
+
+    if changed:
+        db.commit()
+        db.refresh(user)
+    return user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,5 @@ supabase==2.15.1
 python-dotenv==1.0.1
 httpx==0.28.1
 beautifulsoup4==4.12.3
+PyJWT==2.10.1
+cryptography==44.0.0

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   },
   images: {
-    domains: [],
+    domains: ["lh3.googleusercontent.com"],
   },
 };
 

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getSupabaseServerClient } from "@/lib/supabase/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") || "/";
+
+  if (code) {
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error && data.session) {
+      // バックエンドにusers行がまだ無い（=初回ログイン）なら、確認画面を経由させてから登録する
+      const meRes = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
+        headers: { Authorization: `Bearer ${data.session.access_token}` },
+        cache: "no-store",
+      });
+
+      if (meRes.status === 404) {
+        const registerUrl = new URL("/register", origin);
+        registerUrl.searchParams.set("next", next);
+        return NextResponse.redirect(registerUrl);
+      }
+
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login`);
+}

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -13,19 +13,23 @@ export async function GET(request: Request) {
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error && data.session) {
-      // バックエンドにusers行がまだ無い（=初回ログイン）なら、確認画面を経由させてから登録する
+      // バックエンドにusers行がまだ無い（=初回ログイン）なら、確認画面を経由させてから登録する。
+      // /auth/meが200（登録済み）でも404（未登録）でもない場合（5xx等の一時的な障害）は、
+      // 未登録のまま素通りさせず、登録済みかどうか不明な状態としてログイン画面に戻す
       const meRes = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
         headers: { Authorization: `Bearer ${data.session.access_token}` },
         cache: "no-store",
       });
+
+      if (meRes.ok) {
+        return NextResponse.redirect(`${origin}${next}`);
+      }
 
       if (meRes.status === 404) {
         const registerUrl = new URL("/register", origin);
         registerUrl.searchParams.set("next", next);
         return NextResponse.redirect(registerUrl);
       }
-
-      return NextResponse.redirect(`${origin}${next}`);
     }
   }
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getSupabaseClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/Button";
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
+  const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleGoogleLogin() {
+    setIsLoading(true);
+    const redirect = searchParams.get("redirect") || "/";
+    const callbackUrl = new URL("/auth/callback", window.location.origin);
+    callbackUrl.searchParams.set("next", redirect);
+
+    await getSupabaseClient().auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: callbackUrl.toString() },
+    });
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="card w-full max-w-sm p-8 text-center">
+        <h1 className="text-xl font-bold text-sfc-blue">SFC Portal</h1>
+        <p className="mt-2 text-sm text-gray-500">
+          慶應義塾大学SFCのアカウントでログインしてください。
+        </p>
+        <Button
+          className="mt-6 w-full"
+          onClick={handleGoogleLogin}
+          isLoading={isLoading}
+        >
+          Googleでログイン
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,6 +2,12 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { useAuthListener } from "@/lib/hooks/useAuth";
+
+function AuthListener({ children }: { children: React.ReactNode }) {
+  useAuthListener();
+  return <>{children}</>;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -14,6 +20,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthListener>{children}</AuthListener>
+    </QueryClientProvider>
   );
 }

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import Image from "next/image";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { getSupabaseClient } from "@/lib/supabase/client";
+import { registerAccount } from "@/lib/api/auth";
+import { Button } from "@/components/ui/Button";
+
+export default function RegisterPage() {
+  return (
+    <Suspense>
+      <RegisterConfirmation />
+    </Suspense>
+  );
+}
+
+interface GoogleAccountPreview {
+  email: string;
+  displayName: string;
+  avatarUrl?: string;
+}
+
+function RegisterConfirmation() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const next = searchParams.get("next") || "/";
+
+  const [account, setAccount] = useState<GoogleAccountPreview | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSupabaseClient()
+      .auth.getUser()
+      .then(({ data: { user } }) => {
+        if (!user) {
+          router.replace("/login");
+          return;
+        }
+        const metadata = user.user_metadata ?? {};
+        setAccount({
+          email: user.email ?? "",
+          displayName: metadata.full_name || metadata.name || user.email || "",
+          avatarUrl: metadata.avatar_url || metadata.picture,
+        });
+      });
+  }, [router]);
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await registerAccount();
+      await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+      router.replace(next);
+    } catch {
+      setError("アカウント作成に失敗しました。時間をおいて再度お試しください。");
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleCancel() {
+    await getSupabaseClient().auth.signOut();
+    router.replace("/login");
+  }
+
+  if (!account) return null;
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="card w-full max-w-sm p-8 text-center">
+        <h1 className="text-xl font-bold text-sfc-blue">アカウントを作成</h1>
+        <p className="mt-2 text-sm text-gray-500">
+          このGoogleアカウントでSFC Portalのアカウントを新規作成します。
+        </p>
+
+        <div className="mt-6 flex flex-col items-center gap-2">
+          {account.avatarUrl && (
+            <Image
+              src={account.avatarUrl}
+              alt=""
+              width={48}
+              height={48}
+              className="rounded-full"
+            />
+          )}
+          <p className="font-medium text-gray-800">{account.displayName}</p>
+          <p className="text-sm text-gray-500">{account.email}</p>
+        </div>
+
+        {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+
+        <div className="mt-6 flex flex-col gap-2">
+          <Button className="w-full" onClick={handleConfirm} isLoading={isSubmitting}>
+            アカウントを作成して続ける
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={handleCancel}
+            disabled={isSubmitting}
+          >
+            キャンセル
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { TaskList } from "@/components/tasks/TaskList";
 import { TaskForm } from "@/components/tasks/TaskForm";
+import { useAiSubdivideStore } from "@/lib/stores/aiSubdivideStore";
 
 // === AI細分化の説明アイコン ===
 function AiFeatureInfo() {
@@ -29,7 +30,57 @@ function AiFeatureInfo() {
           タイトル・説明・期間をAIが読み取り、ちょうどよい粒度のサブタスクへ自動で分割します。
           各タスクのカードにある「AI細分化」ボタンから利用でき、期間が未設定の場合は今日を基準に分割します。
         </p>
+        <p className="mt-2 text-gray-500">
+          利用回数には上限があり、1時間あたり10回までご利用いただけます。
+        </p>
       </div>
+    </div>
+  );
+}
+
+// === AI細分化の利用制限中メッセージ（レート制限に達している間、上のAiFeatureInfoの代わりに表示）===
+// user: このユーザー自身が1時間10回の上限に達した / api: Gemini API自体がアプリ全体で上限に達した（他ユーザー分も含む）
+function AiFeatureRateLimited({ until, reason }: { until: number; reason: "user" | "api" }) {
+  const remainingMinutes = Math.max(1, Math.ceil((until - Date.now()) / 60_000));
+  const message =
+    reason === "user"
+      ? `AI細分化のご利用回数が上限に達しました（約${remainingMinutes}分後に再度利用できます）`
+      : `Gemini APIの利用上限に達しています。アプリ全体の制限のため今しばらくお待ちください（約${remainingMinutes}分後に再度利用できます）`;
+
+  return (
+    <div className="flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-700">
+      <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+      </svg>
+      {message}
+    </div>
+  );
+}
+
+function AiFeatureStatus() {
+  const userRateLimitedUntil = useAiSubdivideStore((s) => s.userRateLimitedUntil);
+  const apiRateLimitedUntil = useAiSubdivideStore((s) => s.apiRateLimitedUntil);
+  const [, forceTick] = useState(0);
+
+  // 制限が設定されている間は定期的に再評価し、期限が切れたら自動でAiFeatureInfoに戻す
+  useEffect(() => {
+    if (!userRateLimitedUntil && !apiRateLimitedUntil) return;
+    const id = setInterval(() => forceTick((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, [userRateLimitedUntil, apiRateLimitedUntil]);
+
+  const now = Date.now();
+  const isUserLimited = !!userRateLimitedUntil && userRateLimitedUntil > now;
+  const isApiLimited = !!apiRateLimitedUntil && apiRateLimitedUntil > now;
+
+  if (!isUserLimited && !isApiLimited) {
+    return <AiFeatureInfo />;
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      {isUserLimited && <AiFeatureRateLimited until={userRateLimitedUntil} reason="user" />}
+      {isApiLimited && <AiFeatureRateLimited until={apiRateLimitedUntil} reason="api" />}
     </div>
   );
 }
@@ -42,7 +93,7 @@ export default function TasksPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">タスク管理</h1>
         <div className="flex items-center gap-3">
-          <AiFeatureInfo />
+          <AiFeatureStatus />
           <button
             onClick={() => setShowForm(true)}
             className="btn-primary"

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useState } from "react";
-import { Menu, X } from "lucide-react";
+import Image from "next/image";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Menu, User as UserIcon, X } from "lucide-react";
 import { clsx } from "clsx";
+import { useAuthStore } from "@/lib/stores/authStore";
+import { useCurrentUser } from "@/lib/hooks/useAuth";
+import { deleteAccount } from "@/lib/api/auth";
+import { getSupabaseClient } from "@/lib/supabase/client";
 
 const NAV = [
   { label: "ホーム", href: "/" },
@@ -14,6 +20,104 @@ const NAV = [
   { label: "SNS", href: "/sns" },
   { label: "バス", href: "/bus" },
 ];
+
+function AuthArea() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const logout = useAuthStore((s) => s.logout);
+  const { data: user } = useCurrentUser();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [menuOpen]);
+
+  async function handleLogout() {
+    await getSupabaseClient().auth.signOut();
+    logout();
+    setMenuOpen(false);
+    router.refresh();
+  }
+
+  async function handleDeleteAccount() {
+    if (
+      !window.confirm(
+        "アカウントを削除します。保有するすべてのタスクも削除され、元に戻せません。本当によろしいですか？"
+      )
+    ) {
+      return;
+    }
+    setIsDeleting(true);
+    try {
+      await deleteAccount();
+      await getSupabaseClient().auth.signOut();
+      logout();
+      queryClient.removeQueries({ queryKey: ["currentUser"] });
+      router.push("/login");
+    } catch {
+      window.alert("アカウント削除に失敗しました。時間をおいて再度お試しください。");
+      setIsDeleting(false);
+    }
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Link href="/login" className="px-3 py-1.5 rounded-md text-sm hover:bg-white/10">
+        ログイン
+      </Link>
+    );
+  }
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setMenuOpen((v) => !v)}
+        className="flex items-center gap-2 rounded-md px-2 py-1 hover:bg-white/10 transition-colors"
+        aria-label="アカウントメニュー"
+      >
+        {user?.avatarUrl ? (
+          <Image src={user.avatarUrl} alt="" width={24} height={24} className="rounded-full" />
+        ) : (
+          <UserIcon className="h-5 w-5" />
+        )}
+        {user?.displayName && <span className="text-sm">{user.displayName}</span>}
+      </button>
+
+      {menuOpen && (
+        <div className="absolute right-0 top-full mt-2 w-56 rounded-xl border border-gray-200 bg-white text-gray-700 shadow-lg overflow-hidden z-10">
+          {user?.email && (
+            <div className="px-4 py-2.5 border-b border-gray-100 text-xs text-gray-500 truncate">
+              {user.email}
+            </div>
+          )}
+          <button
+            onClick={handleLogout}
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors"
+          >
+            ログアウト
+          </button>
+          <button
+            onClick={handleDeleteAccount}
+            disabled={isDeleting}
+            className="w-full text-left px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50"
+          >
+            {isDeleting ? "削除中…" : "アカウントを削除"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function Navbar() {
   const pathname = usePathname();
@@ -34,6 +138,10 @@ export function Navbar() {
           ))}
         </ul>
 
+        <div className="hidden md:block">
+          <AuthArea />
+        </div>
+
         <button className="md:hidden" onClick={() => setOpen((v) => !v)} aria-label="メニュー">
           {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </button>
@@ -50,6 +158,9 @@ export function Navbar() {
               </li>
             ))}
           </ul>
+          <div className="pt-2 border-t border-white/20 mt-2">
+            <AuthArea />
+          </div>
         </div>
       )}
     </nav>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -3,12 +3,13 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Menu, User as UserIcon, X } from "lucide-react";
 import { clsx } from "clsx";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { useCurrentUser } from "@/lib/hooks/useAuth";
+import { useOnClickOutside } from "@/lib/hooks/useOnClickOutside";
 import { deleteAccount } from "@/lib/api/auth";
 import { getSupabaseClient } from "@/lib/supabase/client";
 
@@ -31,16 +32,7 @@ function AuthArea() {
   const [isDeleting, setIsDeleting] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!menuOpen) return;
-    function handleClickOutside(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [menuOpen]);
+  useOnClickOutside(menuRef, () => setMenuOpen(false), menuOpen);
 
   async function handleLogout() {
     await getSupabaseClient().auth.signOut();

--- a/frontend/src/components/tasks/ActiveButton.tsx
+++ b/frontend/src/components/tasks/ActiveButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useUpdateTask } from "@/lib/hooks/useTasks";
+import type { Task } from "@/types/task";
+
+export function ActiveButton({ task }: { task: Task }) {
+  const updateTask = useUpdateTask();
+  if (task.status === "done") return null;
+
+  const isActive = task.status === "in_progress";
+
+  function toggle(e: React.MouseEvent) {
+    e.stopPropagation();
+    updateTask.mutate({ id: task.id, input: { status: isActive ? "todo" : "in_progress" } });
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={updateTask.isPending}
+      title={isActive ? "進行中（クリックで停止）" : "開始する"}
+      className={`flex-shrink-0 flex items-center gap-1 text-sm font-medium px-2.5 py-1 rounded-full border transition-all ${
+        isActive
+          ? "bg-sfc-blue text-white border-sfc-blue"
+          : "text-gray-500 border-gray-200 hover:border-sfc-blue hover:text-sfc-blue"
+      }`}
+    >
+      <svg
+        className="w-3 h-3"
+        fill={isActive ? "currentColor" : "none"}
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+      </svg>
+      {isActive ? "進行中" : "開始"}
+    </button>
+  );
+}

--- a/frontend/src/components/tasks/DateRangePicker.tsx
+++ b/frontend/src/components/tasks/DateRangePicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
+import { useOnClickOutside } from "@/lib/hooks/useOnClickOutside";
 
 export interface DateRangePickerProps {
   startDate?: string; // "YYYY-MM-DD" or ISO
@@ -36,15 +37,7 @@ export function DateRangePicker({ startDate, endDate, onChange }: DateRangePicke
   const [popupPos, setPopupPos] = useState({ top: 0, left: 0 });
 
   // Close on outside click
-  useEffect(() => {
-    if (!open) return;
-    const h = (e: MouseEvent) => {
-      const t = e.target as Node;
-      if (!triggerRef.current?.contains(t) && !popupRef.current?.contains(t)) setOpen(false);
-    };
-    document.addEventListener("mousedown", h);
-    return () => document.removeEventListener("mousedown", h);
-  }, [open]);
+  useOnClickOutside([triggerRef, popupRef], () => setOpen(false), open);
 
   function handleOpen() {
     if (open) { setOpen(false); return; }

--- a/frontend/src/components/tasks/SubTaskAddForm.tsx
+++ b/frontend/src/components/tasks/SubTaskAddForm.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useRef, useEffect, KeyboardEvent } from "react";
+import { useCreateSubtask } from "@/lib/hooks/useTasks";
+import { DateRangePicker } from "./DateRangePicker";
+
+export function SubTaskAddForm({ parentId, onDone }: { parentId: string; onDone: () => void }) {
+  const createSubtask = useCreateSubtask();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState<string | undefined>();
+  const [dueDate, setDueDate] = useState<string | undefined>();
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { titleRef.current?.focus(); }, []);
+
+  function submit() {
+    const t = title.trim();
+    if (!t) return;
+    createSubtask.mutate(
+      { parentId, input: { title: t, description: description || undefined, startDate, dueDate } },
+      { onSuccess: onDone },
+    );
+  }
+
+  return (
+    <div className="card p-4 space-y-3">
+      <p className="text-sm font-medium text-gray-600">サブタスクを追加</p>
+      <input
+        ref={titleRef}
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+          if (e.key === "Enter") { e.preventDefault(); submit(); }
+          if (e.key === "Escape") onDone();
+        }}
+        placeholder="タスク名 *"
+        disabled={createSubtask.isPending}
+        className="input-base w-full"
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="説明（任意）"
+        rows={2}
+        disabled={createSubtask.isPending}
+        className="input-base w-full resize-none text-sm"
+      />
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">期間</label>
+        <DateRangePicker
+          startDate={startDate}
+          endDate={dueDate}
+          onChange={(s, e) => { setStartDate(s); setDueDate(e); }}
+        />
+      </div>
+      <p className="text-sm text-gray-500">優先度・タグ・カテゴリは親タスクから自動引き継ぎ</p>
+      <div className="flex gap-2 justify-end pt-1">
+        <button type="button" onClick={onDone}
+          className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5">キャンセル</button>
+        <button type="button" onClick={submit}
+          disabled={!title.trim() || createSubtask.isPending}
+          className="btn-primary text-sm disabled:opacity-40 disabled:cursor-not-allowed">
+          {createSubtask.isPending ? "追加中…" : "追加"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/tasks/TagSelector.tsx
+++ b/frontend/src/components/tasks/TagSelector.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef, useEffect, KeyboardEvent } from "react";
+import { useState, useRef, KeyboardEvent } from "react";
 import { useAvailableTags } from "@/lib/hooks/useTasks";
+import { useOnClickOutside } from "@/lib/hooks/useOnClickOutside";
 
 // デフォルトタグ（初期状態で選択肢として表示）
 const DEFAULT_TAGS = ["課題", "試験", "プロジェクト", "読書", "仕事", "個人", "重要", "開発", "その他"];
@@ -43,15 +44,7 @@ export function TagSelector({ selected, onChange }: TagSelectorProps) {
   const canCreate = input.trim() && !available.includes(input.trim()) && !selected.includes(input.trim());
 
   // 外クリックで閉じる
-  useEffect(() => {
-    if (!open) return;
-    const h = (e: MouseEvent) => {
-      const t = e.target as Node;
-      if (!triggerRef.current?.contains(t) && !dropdownRef.current?.contains(t)) setOpen(false);
-    };
-    document.addEventListener("mousedown", h);
-    return () => document.removeEventListener("mousedown", h);
-  }, [open]);
+  useOnClickOutside([triggerRef, dropdownRef], () => setOpen(false), open);
 
   function openDropdown() {
     if (!triggerRef.current) return;

--- a/frontend/src/components/tasks/TaskItem.tsx
+++ b/frontend/src/components/tasks/TaskItem.tsx
@@ -1,155 +1,20 @@
 "use client";
 
-import { Fragment, useState, useRef, useEffect, KeyboardEvent } from "react";
+import { Fragment, useState } from "react";
 import axios from "axios";
-import { useUpdateTask, useDeleteTask, useCreateSubtask, useSubdivideTask } from "@/lib/hooks/useTasks";
+import { useUpdateTask, useDeleteTask, useSubdivideTask } from "@/lib/hooks/useTasks";
 import { useAiSubdivideStore } from "@/lib/stores/aiSubdivideStore";
 import { TaskForm } from "./TaskForm";
-import { DateRangePicker } from "./DateRangePicker";
-import type { Task, TaskPriority, TaskStatus } from "@/types/task";
-
-// === 定数 ===
-const PRIORITY_STYLES: Record<TaskPriority, string> = {
-  low: "bg-gray-100 text-gray-600",
-  medium: "bg-blue-100 text-blue-700",
-  high: "bg-orange-100 text-orange-700",
-  urgent: "bg-red-100 text-red-700",
-};
-const PRIORITY_LABELS: Record<TaskPriority, string> = {
-  low: "低", medium: "中", high: "高", urgent: "緊急",
-};
-
-function formatDate(d?: string) {
-  if (!d) return null;
-  // タイムゾーン問題を避けるため日付文字列を直接パース
-  const [, m, day] = d.split("T")[0].split("-");
-  return `${parseInt(m)}/${parseInt(day)}`;
-}
-function isOverdue(d?: string, status?: TaskStatus) {
-  if (!d || status === "done") return false;
-  // 当日EODまでは期限切れとしない
-  const [y, m, day] = d.split("T")[0].split("-").map(Number);
-  return new Date(y, m - 1, day, 23, 59, 59) < new Date();
-}
-function periodText(task: Task) {
-  const sDay = task.startDate?.split("T")[0];
-  const eDay = task.dueDate?.split("T")[0];
-  const s = formatDate(task.startDate);
-  const e = formatDate(task.dueDate);
-  // 同じ日 or 片方のみ → arrowなし
-  if (s && e && sDay !== eDay) return `${s} → ${e}`;
-  if (s) return s;
-  if (e) return e;
-  return null;
-}
-// 4行以上 or 180文字以上の場合だけ展開ボタンを表示
-function needsExpand(desc?: string) {
-  if (!desc?.trim()) return false;
-  return (desc.split("\n").length > 3) || (desc.length > 180);
-}
-
-// === サブタスク追加フォーム ===
-function SubTaskAddForm({ parentId, onDone }: { parentId: string; onDone: () => void }) {
-  const createSubtask = useCreateSubtask();
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [startDate, setStartDate] = useState<string | undefined>();
-  const [dueDate, setDueDate] = useState<string | undefined>();
-  const titleRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => { titleRef.current?.focus(); }, []);
-
-  function submit() {
-    const t = title.trim();
-    if (!t) return;
-    createSubtask.mutate(
-      { parentId, input: { title: t, description: description || undefined, startDate, dueDate } },
-      { onSuccess: onDone },
-    );
-  }
-
-  return (
-    <div className="card p-4 space-y-3">
-      <p className="text-sm font-medium text-gray-600">サブタスクを追加</p>
-      <input
-        ref={titleRef}
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === "Enter") { e.preventDefault(); submit(); }
-          if (e.key === "Escape") onDone();
-        }}
-        placeholder="タスク名 *"
-        disabled={createSubtask.isPending}
-        className="input-base w-full"
-      />
-      <textarea
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        placeholder="説明（任意）"
-        rows={2}
-        disabled={createSubtask.isPending}
-        className="input-base w-full resize-none text-sm"
-      />
-      <div>
-        <label className="block text-xs font-medium text-gray-600 mb-1">期間</label>
-        <DateRangePicker
-          startDate={startDate}
-          endDate={dueDate}
-          onChange={(s, e) => { setStartDate(s); setDueDate(e); }}
-        />
-      </div>
-      <p className="text-sm text-gray-500">優先度・タグ・カテゴリは親タスクから自動引き継ぎ</p>
-      <div className="flex gap-2 justify-end pt-1">
-        <button type="button" onClick={onDone}
-          className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5">キャンセル</button>
-        <button type="button" onClick={submit}
-          disabled={!title.trim() || createSubtask.isPending}
-          className="btn-primary text-sm disabled:opacity-40 disabled:cursor-not-allowed">
-          {createSubtask.isPending ? "追加中…" : "追加"}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-// === 状態（アクティブ）ボタン ===
-function ActiveButton({ task }: { task: Task }) {
-  const updateTask = useUpdateTask();
-  if (task.status === "done") return null;
-
-  const isActive = task.status === "in_progress";
-
-  function toggle(e: React.MouseEvent) {
-    e.stopPropagation();
-    updateTask.mutate({ id: task.id, input: { status: isActive ? "todo" : "in_progress" } });
-  }
-
-  return (
-    <button
-      onClick={toggle}
-      disabled={updateTask.isPending}
-      title={isActive ? "進行中（クリックで停止）" : "開始する"}
-      className={`flex-shrink-0 flex items-center gap-1 text-sm font-medium px-2.5 py-1 rounded-full border transition-all ${
-        isActive
-          ? "bg-sfc-blue text-white border-sfc-blue"
-          : "text-gray-500 border-gray-200 hover:border-sfc-blue hover:text-sfc-blue"
-      }`}
-    >
-      <svg
-        className="w-3 h-3"
-        fill={isActive ? "currentColor" : "none"}
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round"
-          d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
-      </svg>
-      {isActive ? "進行中" : "開始"}
-    </button>
-  );
-}
+import { SubTaskAddForm } from "./SubTaskAddForm";
+import { ActiveButton } from "./ActiveButton";
+import {
+  PRIORITY_STYLES,
+  PRIORITY_LABELS,
+  isOverdue,
+  periodText,
+  needsExpand,
+} from "@/lib/utils/taskDisplay";
+import type { Task } from "@/types/task";
 
 // === 統一タスクカード ===
 interface TaskCardProps {

--- a/frontend/src/components/tasks/TaskItem.tsx
+++ b/frontend/src/components/tasks/TaskItem.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useState, useRef, useEffect, KeyboardEvent } from "react";
 import axios from "axios";
 import { useUpdateTask, useDeleteTask, useCreateSubtask, useSubdivideTask } from "@/lib/hooks/useTasks";
+import { useAiSubdivideStore } from "@/lib/stores/aiSubdivideStore";
 import { TaskForm } from "./TaskForm";
 import { DateRangePicker } from "./DateRangePicker";
 import type { Task, TaskPriority, TaskStatus } from "@/types/task";
@@ -161,6 +162,14 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
   const updateTask = useUpdateTask();
   const deleteTask = useDeleteTask();
   const subdivideTask = useSubdivideTask();
+  const userRateLimitedUntil = useAiSubdivideStore((s) => s.userRateLimitedUntil);
+  const apiRateLimitedUntil = useAiSubdivideStore((s) => s.apiRateLimitedUntil);
+  const setUserRateLimited = useAiSubdivideStore((s) => s.setUserRateLimited);
+  const setApiRateLimited = useAiSubdivideStore((s) => s.setApiRateLimited);
+  const now = Date.now();
+  const isSubdivideRateLimited =
+    (!!userRateLimitedUntil && userRateLimitedUntil > now) ||
+    (!!apiRateLimitedUntil && apiRateLimitedUntil > now);
   const [descExpanded, setDescExpanded] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
   const [subtasksOpen, setSubtasksOpen] = useState(false);
@@ -197,12 +206,23 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
 
   function handleSubdivideClick(e: React.MouseEvent) {
     e.stopPropagation();
+    if (isSubdivideRateLimited) return;
     setSubtasksOpen(true);
     subdivideTask.mutate(task.id, {
       onError: (err) => {
         const detail = axios.isAxiosError(err)
           ? (err.response?.data as { detail?: string } | undefined)?.detail
           : undefined;
+        if (axios.isAxiosError(err) && err.response?.status === 429) {
+          const retryAfter = Number(err.response.headers["retry-after"]) || 3600;
+          const scope = err.response.headers["x-ratelimit-scope"];
+          if (scope === "api") {
+            setApiRateLimited(retryAfter);
+          } else {
+            setUserRateLimited(retryAfter);
+          }
+          return;
+        }
         window.alert(detail || "AI細分化に失敗しました");
       },
     });
@@ -395,14 +415,14 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
               <div className="flex items-center gap-3">
                 <button
                   onClick={handleSubdivideClick}
-                  disabled={subdivideTask.isPending}
-                  title="AIでサブタスクに分割"
+                  disabled={subdivideTask.isPending || isSubdivideRateLimited}
+                  title={isSubdivideRateLimited ? "AI細分化は現在ご利用いただけません" : "AIでサブタスクに分割"}
                   className="text-sm font-medium text-gray-600 hover:text-sfc-blue transition-colors flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-600"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
                   </svg>
-                  {subdivideTask.isPending ? "生成中…" : "AI細分化"}
+                  {subdivideTask.isPending ? "生成中…" : isSubdivideRateLimited ? "利用制限中" : "AI細分化"}
                 </button>
                 <button
                   onClick={handleAddSubtaskClick}

--- a/frontend/src/components/tasks/TaskItem.tsx
+++ b/frontend/src/components/tasks/TaskItem.tsx
@@ -216,10 +216,14 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
         if (axios.isAxiosError(err) && err.response?.status === 429) {
           const retryAfter = Number(err.response.headers["retry-after"]) || 3600;
           const scope = err.response.headers["x-ratelimit-scope"];
-          if (scope === "api") {
+          // scope="ip"（API全体への簡易フラッド対策）はこのユーザー個人のAI利用制限ではないため、
+          // 誤って「利用制限中」表示にしない。user/api以外は汎用エラーとして扱う
+          if (scope === "user") {
+            setUserRateLimited(retryAfter);
+          } else if (scope === "api") {
             setApiRateLimited(retryAfter);
           } else {
-            setUserRateLimited(retryAfter);
+            window.alert("リクエストが多すぎます。しばらく待ってから再度お試しください。");
           }
           return;
         }

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -6,6 +6,15 @@ export async function getCurrentUser(): Promise<User> {
   return data;
 }
 
+export async function registerAccount(): Promise<User> {
+  const { data } = await apiClient.post("/auth/register");
+  return data;
+}
+
+export async function deleteAccount(): Promise<void> {
+  await apiClient.delete("/auth/me");
+}
+
 export async function getUserProfile(userId: string): Promise<UserProfile> {
   const { data } = await apiClient.get(`/users/${userId}/profile`);
   return data;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosError } from "axios";
 import type { ApiError } from "@/types/common";
+import { getSupabaseClient } from "@/lib/supabase/client";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -30,10 +31,15 @@ export const apiClient: AxiosInstance = axios.create({
 });
 
 // リクエスト: camelCase → snake_case + 認証トークン付与
-apiClient.interceptors.request.use((config) => {
+// トークンはSupabase-jsが管理するセッションから都度取得する（自前でlocalStorageに保持しない）
+apiClient.interceptors.request.use(async (config) => {
   if (typeof window !== "undefined") {
-    const token = localStorage.getItem("access_token");
-    if (token) config.headers.Authorization = `Bearer ${token}`;
+    const {
+      data: { session },
+    } = await getSupabaseClient().auth.getSession();
+    if (session?.access_token) {
+      config.headers.Authorization = `Bearer ${session.access_token}`;
+    }
   }
   if (config.data && typeof config.data === "object") {
     config.data = mapKeys(config.data, toSnake);
@@ -48,8 +54,16 @@ apiClient.interceptors.response.use(
     return response;
   },
   (error: AxiosError<ApiError>) => {
-    if (error.response?.status === 401) {
-      if (typeof window !== "undefined") localStorage.removeItem("access_token");
+    // ログイン済みだがアカウント作成確認が未完了のセッション（別タブ等）を確認画面へ誘導する
+    const detail = (error.response?.data as { detail?: string } | undefined)?.detail;
+    if (
+      typeof window !== "undefined" &&
+      error.response?.status === 403 &&
+      detail === "account_not_registered"
+    ) {
+      const registerUrl = new URL("/register", window.location.origin);
+      registerUrl.searchParams.set("next", window.location.pathname);
+      window.location.href = registerUrl.toString();
     }
     return Promise.reject(error);
   }

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -1,16 +1,61 @@
 "use client";
 
+import { useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getCurrentUser, updateProfile } from "@/lib/api/auth";
+import { getSupabaseClient } from "@/lib/supabase/client";
+import { useAuthStore } from "@/lib/stores/authStore";
 import type { User, UserProfile } from "@/types/user";
 
 export function useCurrentUser() {
-  return useQuery<User>({
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const setUser = useAuthStore((s) => s.setUser);
+
+  const query = useQuery<User>({
     queryKey: ["currentUser"],
     queryFn: getCurrentUser,
+    enabled: isAuthenticated,
     retry: false,
     staleTime: 5 * 60 * 1000,
   });
+
+  useEffect(() => {
+    if (query.data) setUser(query.data);
+  }, [query.data, setUser]);
+
+  return query;
+}
+
+// Supabaseのログイン状態変化を購読し、authStoreとReact Queryのキャッシュに反映する。
+// アプリ全体で1回だけ（Providers配下で）呼び出す。
+// isAuthenticatedはSupabaseセッションの有無のみで決まる（バックエンドの/auth/me取得結果には依存しない、
+// でないとuseCurrentUserのenabled条件と循環してしまう）。
+export function useAuthListener() {
+  const queryClient = useQueryClient();
+  const setAuthenticated = useAuthStore((s) => s.setAuthenticated);
+  const logout = useAuthStore((s) => s.logout);
+
+  useEffect(() => {
+    const supabase = getSupabaseClient();
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setAuthenticated(!!session);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session) {
+        logout();
+        queryClient.removeQueries({ queryKey: ["currentUser"] });
+      } else {
+        setAuthenticated(true);
+        queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [queryClient, setAuthenticated, logout]);
 }
 
 export function useUpdateProfile() {

--- a/frontend/src/lib/hooks/useOnClickOutside.ts
+++ b/frontend/src/lib/hooks/useOnClickOutside.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+type ClickOutsideRef = RefObject<HTMLElement | null>;
+
+// トリガー要素・ポップアップ要素など複数の要素を跨いで「外側クリックで閉じる」を判定する共通フック
+export function useOnClickOutside(
+  refs: ClickOutsideRef | ClickOutsideRef[],
+  onOutside: () => void,
+  enabled = true
+) {
+  const callbackRef = useRef(onOutside);
+  callbackRef.current = onOutside;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const refList = Array.isArray(refs) ? refs : [refs];
+
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      const isInside = refList.some((ref) => ref.current?.contains(target));
+      if (!isInside) callbackRef.current();
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+    // refsはuseRefで生成される安定参照のため依存配列に含めなくてよい
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+}

--- a/frontend/src/lib/stores/aiSubdivideStore.ts
+++ b/frontend/src/lib/stores/aiSubdivideStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+// AI細分化が使えなくなる2つの独立したケースを別々に管理する。
+// - userRateLimitedUntil: このユーザー自身がバックエンドの制限（1ユーザー10回/時間）に達した
+// - apiRateLimitedUntil: Gemini API自体がアプリ全体で利用上限に達している（他ユーザー分も含む共有の制限）
+// どちらもタスクカード単位ではなくアプリ全体で共有する。
+interface AiSubdivideStore {
+  userRateLimitedUntil: number | null; // epoch ms
+  apiRateLimitedUntil: number | null; // epoch ms
+  setUserRateLimited: (retryAfterSeconds: number) => void;
+  setApiRateLimited: (retryAfterSeconds: number) => void;
+  clear: () => void;
+}
+
+export const useAiSubdivideStore = create<AiSubdivideStore>()((set) => ({
+  userRateLimitedUntil: null,
+  apiRateLimitedUntil: null,
+  setUserRateLimited: (retryAfterSeconds) =>
+    set({ userRateLimitedUntil: Date.now() + retryAfterSeconds * 1000 }),
+  setApiRateLimited: (retryAfterSeconds) =>
+    set({ apiRateLimitedUntil: Date.now() + retryAfterSeconds * 1000 }),
+  clear: () => set({ userRateLimitedUntil: null, apiRateLimitedUntil: null }),
+}));

--- a/frontend/src/lib/stores/authStore.ts
+++ b/frontend/src/lib/stores/authStore.ts
@@ -1,27 +1,20 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
-import type { User } from "@/types/user";
+import type { AuthState, User } from "@/types/user";
 
-interface AuthState {
-  user: User | null;
-  accessToken: string | null;
+// アクセストークンはSupabase-jsが自前で永続化・更新するため、ここでは持たない
+// （client.tsのAPIリクエスト時にgetSupabaseClient().auth.getSession()から都度取得する）
+// isAuthenticatedはSupabaseセッションの有無のみで更新する（userはバックエンドの/auth/me取得結果）
+interface AuthStore extends AuthState {
   setUser: (user: User | null) => void;
-  setAccessToken: (token: string | null) => void;
+  setAuthenticated: (isAuthenticated: boolean) => void;
   logout: () => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      user: null,
-      accessToken: null,
-      setUser: (user) => set({ user }),
-      setAccessToken: (accessToken) => set({ accessToken }),
-      logout: () => set({ user: null, accessToken: null }),
-    }),
-    {
-      name: "auth-storage",
-      partialize: (state) => ({ accessToken: state.accessToken }),
-    }
-  )
-);
+export const useAuthStore = create<AuthStore>()((set) => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: true,
+  setUser: (user) => set({ user }),
+  setAuthenticated: (isAuthenticated) => set({ isAuthenticated, isLoading: false }),
+  logout: () => set({ user: null, isAuthenticated: false, isLoading: false }),
+}));

--- a/frontend/src/lib/stores/authStore.ts
+++ b/frontend/src/lib/stores/authStore.ts
@@ -18,3 +18,9 @@ export const useAuthStore = create<AuthStore>()((set) => ({
   setAuthenticated: (isAuthenticated) => set({ isAuthenticated, isLoading: false }),
   logout: () => set({ user: null, isAuthenticated: false, isLoading: false }),
 }));
+
+// 旧実装（zustand persistミドルウェア）が書き込んでいたaccess_token入りの生のlocalStorageキー。
+// 既存ユーザーのブラウザに残り続けないよう、読み込み時に一度だけ削除する
+if (typeof window !== "undefined") {
+  localStorage.removeItem("auth-storage");
+}

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -1,0 +1,49 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+// 個人データを扱うページを保護する。
+// 他機能が実装され次第、この配列に追加するだけで保護対象を拡張できる。
+const PROTECTED_PATHS = ["/tasks", "/timetable", "/sns"];
+
+function isProtectedPath(pathname: string) {
+  return PROTECTED_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+export async function updateSession(request: NextRequest) {
+  let response = NextResponse.next({ request: { headers: request.headers } });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return request.cookies.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          request.cookies.set({ name, value, ...options });
+          response = NextResponse.next({ request: { headers: request.headers } });
+          response.cookies.set({ name, value, ...options });
+        },
+        remove(name: string, options: CookieOptions) {
+          request.cookies.set({ name, value: "", ...options });
+          response = NextResponse.next({ request: { headers: request.headers } });
+          response.cookies.set({ name, value: "", ...options });
+        },
+      },
+    }
+  );
+
+  // getUser()はSupabase側に問い合わせて署名を検証するため、改ざんされたcookieを弾ける
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user && isProtectedPath(request.nextUrl.pathname)) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return response;
+}

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -12,6 +12,11 @@ function isProtectedPath(pathname: string) {
 export async function updateSession(request: NextRequest) {
   let response = NextResponse.next({ request: { headers: request.headers } });
 
+  // 保護対象パス以外はセッション検証（Supabaseへのネットワーク往復）自体が不要なのでスキップする
+  if (!isProtectedPath(request.nextUrl.pathname)) {
+    return response;
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -39,7 +44,7 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user && isProtectedPath(request.nextUrl.pathname)) {
+  if (!user) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", request.nextUrl.pathname);
     return NextResponse.redirect(loginUrl);

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-import { createServerClient } from "@supabase/ssr";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
 export function getSupabaseServerClient() {
@@ -10,6 +10,20 @@ export function getSupabaseServerClient() {
       cookies: {
         get(name: string) {
           return cookieStore.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value, ...options });
+          } catch {
+            // Server Componentから呼ばれた場合はmiddlewareがセッションを更新するため無視してよい
+          }
+        },
+        remove(name: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value: "", ...options });
+          } catch {
+            // 同上
+          }
         },
       },
     }

--- a/frontend/src/lib/utils/taskDisplay.ts
+++ b/frontend/src/lib/utils/taskDisplay.ts
@@ -1,0 +1,43 @@
+import type { Task, TaskPriority, TaskStatus } from "@/types/task";
+
+export const PRIORITY_STYLES: Record<TaskPriority, string> = {
+  low: "bg-gray-100 text-gray-600",
+  medium: "bg-blue-100 text-blue-700",
+  high: "bg-orange-100 text-orange-700",
+  urgent: "bg-red-100 text-red-700",
+};
+export const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: "低", medium: "中", high: "高", urgent: "緊急",
+};
+
+export function formatTaskDate(d?: string) {
+  if (!d) return null;
+  // タイムゾーン問題を避けるため日付文字列を直接パース
+  const [, m, day] = d.split("T")[0].split("-");
+  return `${parseInt(m)}/${parseInt(day)}`;
+}
+
+export function isOverdue(d?: string, status?: TaskStatus) {
+  if (!d || status === "done") return false;
+  // 当日EODまでは期限切れとしない
+  const [y, m, day] = d.split("T")[0].split("-").map(Number);
+  return new Date(y, m - 1, day, 23, 59, 59) < new Date();
+}
+
+export function periodText(task: Task) {
+  const sDay = task.startDate?.split("T")[0];
+  const eDay = task.dueDate?.split("T")[0];
+  const s = formatTaskDate(task.startDate);
+  const e = formatTaskDate(task.dueDate);
+  // 同じ日 or 片方のみ → arrowなし
+  if (s && e && sDay !== eDay) return `${s} → ${e}`;
+  if (s) return s;
+  if (e) return e;
+  return null;
+}
+
+// 4行以上 or 180文字以上の場合だけ展開ボタンを表示
+export function needsExpand(desc?: string) {
+  if (!desc?.trim()) return false;
+  return (desc.split("\n").length > 3) || (desc.length > 180);
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

- ロードマップの最優先課題（`X-User-Id`ヘッダ頼みの仮認証により全員が同じダミーユーザーのデータを見てしまう欠陥）を解消し、Google OAuth × Supabase Authによる本物の認証基盤を実装
- あわせて、Gemini API無料枠を守るための利用制限（ユーザー単位・API全体）も実装
- セキュリティレビュー・コードレビューで見つかった問題（IDOR、OAuthコールバックのエラーハンドリング漏れ、レート制限種別の誤判定など）を修正済み

## 変更内容

**認証基盤**
- Supabase Auth × Google OAuthによるログイン/ログアウト/アカウント削除
- SupabaseのJWKSエンドポイント経由の非対称鍵（ES256）によるバックエンドJWT検証
- 初回ログイン時のアカウント作成確認画面（無断でのユーザー自動作成をやめ、明示的な同意を挟む設計）
- Next.js middlewareによる保護ルート（`/tasks`, `/timetable`, `/sns`）

**コスト保護**
- AI細分化のレート制限（ユーザー単位10回/時間、API全体の簡易フラッド対策）
- Gemini API自体のクォータ超過を区別した利用制限UI（「あなた自身の制限」と「API全体の制限」を別々に表示）

**レビュー指摘の修正**
- `GET /auth/users/{user_id}/profile`のIDOR（本人確認なしに任意ユーザーのPIIを取得可能だった）を修正し、自分自身のみ許可
- OAuthコールバックが`/auth/me`の404以外の非200応答（5xx等）を「登録済み」として素通りしてしまうバグを修正
- AI細分化の429ハンドリングで、IP単位のフラッド制限を誤ってユーザー単位の利用制限として表示してしまうバグを修正
- 旧authStore実装が残す`localStorage["auth-storage"]`（生のaccess_token）のクリーンアップ
- AI細分化のサブタスク日付をtimezone-aware（UTC）に統一

## Test plan

- [x] `npx tsc --noEmit`（フロントエンド）
- [x] `npm run lint`（フロントエンド）
- [x] バックエンドのインポート確認（`from app.main import app`）
- [x] レート制限ロジックの単体テスト（sliding window、scope別ヘッダー、Retry-After計算）
- [x] Gemini 429応答のretryDelayパース（`retryDelay`ヘッダー/JSON本文/なしの3パターン）
- [x] 実際のGoogleアカウントでログイン → JWT検証 → タスク一覧取得のE2E確認
- [x] Playwrightでのレート制限UI表示確認（ユーザー制限のみ/API制限のみ/両方同時の3パターン、スクリーンショット確認）
- [ ] Supabaseダッシュボードでの手動設定（Google OAuth Provider有効化、Redirect URL登録、Spend Cap確認）は別途実施が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)