### PR TITLE
feat: タスク機能・認証画面のモバイル対応

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -31,7 +31,7 @@ function LoginForm() {
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="card w-full max-w-sm p-8 text-center">
+      <div className="card w-full max-w-sm p-6 sm:p-8 text-center">
         <h1 className="text-xl font-bold text-sfc-blue">SFC Portal</h1>
         <p className="mt-2 text-sm text-gray-500">
           慶應義塾大学SFCのアカウントでログインしてください。

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -71,7 +71,7 @@ function RegisterConfirmation() {
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="card w-full max-w-sm p-8 text-center">
+      <div className="card w-full max-w-sm p-6 sm:p-8 text-center">
         <h1 className="text-xl font-bold text-sfc-blue">アカウントを作成</h1>
         <p className="mt-2 text-sm text-gray-500">
           このGoogleアカウントでSFC Portalのアカウントを新規作成します。

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -1,39 +1,49 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TaskList } from "@/components/tasks/TaskList";
 import { TaskForm } from "@/components/tasks/TaskForm";
 import { useAiSubdivideStore } from "@/lib/stores/aiSubdivideStore";
+import { useOnClickOutside } from "@/lib/hooks/useOnClickOutside";
 
 // === AI細分化の説明アイコン ===
+// タップ/クリックで開閉する（hoverのみだとタッチデバイスで説明を読む手段が無くなるため）
 function AiFeatureInfo() {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside(wrapperRef, () => setOpen(false), open);
+
   return (
-    <div className="group relative flex items-center gap-1 cursor-default">
-      <span className="text-sm text-gray-500 group-hover:text-sfc-blue transition-colors">
-        AI細分化とは
-      </span>
+    <div className="relative flex items-center gap-1" ref={wrapperRef}>
       <button
         type="button"
+        onClick={() => setOpen((v) => !v)}
         aria-label="AI細分化機能について"
-        className="flex text-gray-400 group-hover:text-sfc-blue transition-colors"
+        aria-expanded={open}
+        className={`flex items-center gap-1 text-sm transition-colors ${
+          open ? "text-sfc-blue" : "text-gray-500 hover:text-sfc-blue"
+        }`}
       >
+        AI細分化とは
         <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
         </svg>
       </button>
-      <div
-        role="tooltip"
-        className="pointer-events-none absolute right-0 top-full mt-2 w-64 rounded-xl border border-gray-200 bg-white p-3 text-xs leading-relaxed text-gray-600 shadow-lg opacity-0 scale-95 origin-top-right transition-all duration-150 group-hover:opacity-100 group-hover:scale-100 z-10"
-      >
-        <p className="mb-1 text-sm font-semibold text-gray-900">AI細分化</p>
-        <p>
-          タイトル・説明・期間をAIが読み取り、ちょうどよい粒度のサブタスクへ自動で分割します。
-          各タスクのカードにある「AI細分化」ボタンから利用でき、期間が未設定の場合は今日を基準に分割します。
-        </p>
-        <p className="mt-2 text-gray-500">
-          利用回数には上限があり、1時間あたり10回までご利用いただけます。
-        </p>
-      </div>
+      {open && (
+        <div
+          role="tooltip"
+          className="absolute right-0 top-full mt-2 w-64 max-w-[calc(100vw-2rem)] rounded-xl border border-gray-200 bg-white p-3 text-xs leading-relaxed text-gray-600 shadow-lg z-10"
+        >
+          <p className="mb-1 text-sm font-semibold text-gray-900">AI細分化</p>
+          <p>
+            タイトル・説明・期間をAIが読み取り、ちょうどよい粒度のサブタスクへ自動で分割します。
+            各タスクのカードにある「AI細分化」ボタンから利用でき、期間が未設定の場合は今日を基準に分割します。
+          </p>
+          <p className="mt-2 text-gray-500">
+            利用回数には上限があり、1時間あたり10回までご利用いただけます。
+          </p>
+        </div>
+      )}
     </div>
   );
 }
@@ -114,7 +124,7 @@ export default function TasksPage() {
           className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
           onClick={(e) => e.target === e.currentTarget && setShowForm(false)}
         >
-          <div className="card w-full max-w-lg p-6">
+          <div className="card w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto">
             <h2 className="text-lg font-bold text-gray-900 mb-4">新しいタスク</h2>
             <TaskForm
               onSuccess={() => setShowForm(false)}

--- a/frontend/src/components/tasks/DateRangePicker.tsx
+++ b/frontend/src/components/tasks/DateRangePicker.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useRef } from "react";
 import { useOnClickOutside } from "@/lib/hooks/useOnClickOutside";
+import { clampPopupLeft } from "@/lib/utils/popupPosition";
+
+const POPUP_WIDTH = 288; // w-72
 
 export interface DateRangePickerProps {
   startDate?: string; // "YYYY-MM-DD" or ISO
@@ -50,7 +53,7 @@ export function DateRangePicker({ startDate, endDate, onChange }: DateRangePicke
     setHoverDate(undefined);
     if (triggerRef.current) {
       const r = triggerRef.current.getBoundingClientRect();
-      setPopupPos({ top: r.bottom + 6, left: r.left });
+      setPopupPos({ top: r.bottom + 6, left: clampPopupLeft(r.left, POPUP_WIDTH) });
     }
     setOpen(true);
   }

--- a/frontend/src/components/tasks/TagSelector.tsx
+++ b/frontend/src/components/tasks/TagSelector.tsx
@@ -3,6 +3,9 @@
 import { useState, useRef, KeyboardEvent } from "react";
 import { useAvailableTags } from "@/lib/hooks/useTasks";
 import { useOnClickOutside } from "@/lib/hooks/useOnClickOutside";
+import { clampPopupLeft } from "@/lib/utils/popupPosition";
+
+const MIN_DROPDOWN_WIDTH = 220;
 
 // デフォルトタグ（初期状態で選択肢として表示）
 const DEFAULT_TAGS = ["課題", "試験", "プロジェクト", "読書", "仕事", "個人", "重要", "開発", "その他"];
@@ -49,7 +52,8 @@ export function TagSelector({ selected, onChange }: TagSelectorProps) {
   function openDropdown() {
     if (!triggerRef.current) return;
     const r = triggerRef.current.getBoundingClientRect();
-    setDropPos({ top: r.bottom + 4, left: r.left, width: r.width });
+    const width = Math.max(r.width, MIN_DROPDOWN_WIDTH);
+    setDropPos({ top: r.bottom + 4, left: clampPopupLeft(r.left, width), width });
     setOpen(true);
     setTimeout(() => inputRef.current?.focus(), 50);
   }
@@ -132,20 +136,20 @@ export function TagSelector({ selected, onChange }: TagSelectorProps) {
       {open && (
         <div
           ref={dropdownRef}
-          style={{ position: "fixed", top: dropPos.top, left: dropPos.left, width: Math.max(dropPos.width, 220), zIndex: 9999 }}
+          style={{ position: "fixed", top: dropPos.top, left: dropPos.left, width: dropPos.width, zIndex: 9999 }}
           className="bg-white border border-gray-200 rounded-xl shadow-xl py-1 max-h-52 overflow-y-auto"
         >
           {filtered.map((tag) => (
             <div
               key={tag}
-              className="flex items-center justify-between px-3 py-1.5 hover:bg-gray-50 cursor-pointer group"
+              className="flex items-center justify-between px-3 py-1.5 hover:bg-gray-50 cursor-pointer"
               onClick={() => addTag(tag)}
             >
               <span className="text-sm text-gray-700">#{tag}</span>
               <button
                 type="button"
                 onClick={(e) => deleteFromList(tag, e)}
-                className="opacity-0 group-hover:opacity-100 text-gray-300 hover:text-red-400 transition-all text-xs leading-none p-1"
+                className="text-gray-300 hover:text-red-400 transition-colors text-xs leading-none p-1"
                 title="リストから削除"
               >
                 ×

--- a/frontend/src/components/tasks/TaskItem.tsx
+++ b/frontend/src/components/tasks/TaskItem.tsx
@@ -255,7 +255,7 @@ function TaskCard({ task, depth, breadcrumb }: TaskCardProps) {
           className="border-t border-gray-100 px-4 pb-3 pt-2"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between pl-8">
+          <div className="flex flex-wrap items-center justify-between gap-2 pl-8">
             {subTaskCount > 0 ? (
               <button
                 onClick={() => setSubtasksOpen((v) => !v)}

--- a/frontend/src/components/tasks/TaskList.tsx
+++ b/frontend/src/components/tasks/TaskList.tsx
@@ -36,13 +36,13 @@ export function TaskList() {
   return (
     <div className="space-y-4">
       {/* === ステータスフィルター＋ソート === */}
-      <div className="flex items-center justify-between border-b border-gray-200">
-        <div className="flex gap-1">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border-b border-gray-200">
+        <div className="flex gap-1 overflow-x-auto">
           {STATUS_TABS.map((tab) => (
             <button
               key={tab.value}
               onClick={() => setActiveStatus(tab.value)}
-              className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              className={`flex-shrink-0 whitespace-nowrap px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
                 activeStatus === tab.value
                   ? "border-sfc-blue text-sfc-blue"
                   : "border-transparent text-gray-500 hover:text-gray-700"

--- a/frontend/src/lib/utils/popupPosition.ts
+++ b/frontend/src/lib/utils/popupPosition.ts
@@ -1,0 +1,6 @@
+// getBoundingClientRect()由来のleft座標を、ポップアップが画面右端からはみ出さないようクランプする
+export function clampPopupLeft(left: number, popupWidth: number, margin = 8): number {
+  if (typeof window === "undefined") return left;
+  const maxLeft = window.innerWidth - popupWidth - margin;
+  return Math.max(margin, Math.min(left, maxLeft));
+}


### PR DESCRIPTION
## Summary

ロードマップの優先順位2番目（モバイル対応）。`/tasks`関連コンポーネントと`login`/`register`ページを375px幅を想定してレスポンシブ対応した。

## 変更内容

- **ポップアップの画面端クランプ**: `DateRangePicker`/`TagSelector`が`getBoundingClientRect()`の`left`をそのまま使っており、トリガーが画面右寄りにあると画面外にはみ出していた。共通ユーティリティ`lib/utils/popupPosition.ts`の`clampPopupLeft`で対応
- **タッチ操作対応**: 「AI細分化とは」ツールチップをhoverのみからタップ/クリック開閉に変更。`TagSelector`のリスト内削除ボタンも常時表示に変更（どちらもタッチデバイスで操作不能だった）
- **モーダルの高さ対応**: タスク追加モーダルに`max-h-[90vh] overflow-y-auto`を追加（編集モーダルには既にあったが追加モーダルに抜けていた）
- **横並びレイアウトの調整**: `TaskList`のステータスタブ+ソートUIを狭い画面で縦積みに、`TaskItem`のサブタスクボタン行に`flex-wrap`を追加
- login/registerページのカードpaddingを調整

## スコープ外

`syllabus`/`timetable`/`sns`/`bus`はまだスタブ段階のため対象外（`TimetableGrid`の横スクロール依存は機能実装時に再設計）。

## Test plan

- [x] `npx tsc --noEmit` / `npm run lint`
- [x] Playwrightで375px幅の各コンポーネントを目視確認（モックデータによる一時プレビューページ、確認後削除済み）
  - DateRangePicker/TagSelectorのポップアップが画面右端で正しくクランプされる
  - TagSelectorのドロップダウン内削除ボタンが常時表示・タップ可能
  - タスク追加モーダルが正しくレンダリングされる
  - TaskListのタブ+ソートが縦積みになる
  - TaskItemのサブタスクボタン行・利用制限中表示が正しく折り返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)